### PR TITLE
Epic/lisence

### DIFF
--- a/src/common/dto/lisence/CreateLisenceDto.ts
+++ b/src/common/dto/lisence/CreateLisenceDto.ts
@@ -1,24 +1,28 @@
-import { IsDate, IsDateString, IsOptional, IsString } from 'class-validator';
+import { IsDate, IsDateString, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class CreateLisenceDto {
   @IsString()
+  @IsNotEmpty()
   pks!: string;
 
+  @IsOptional()
   @IsString()
-  bast!: string;
+  file_pks_id?: number;
+
+  @IsOptional()
+  @IsString()
+  file_bast_id?: number;
 
   @IsString()
-  aplikasi!: string;
+  @IsNotEmpty()
+  application!: string;
 
   @IsDateString()
-  @IsOptional()
-  due_date_license!: Date;
+  due_date_license!: string;
 
   @IsDateString()
-  @IsOptional()
-  health_check_routine!: Date;
+  health_check_routine!: string;
 
   @IsDateString()
-  @IsOptional()
-  health_check_actual!: Date;
+  health_check_actual!: string;
 }

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -17,12 +17,14 @@ const configConstants = {
   JWT_EXPIRES_IN: process.env.JWT_EXPIRES_IN ?? '1d',
   JWT_SECRET_REFRESH_TOKEN: process.env.JWT_SECRET_REFRESH_TOKEN ?? 'secret',
   JWT_REFRESH_EXPIRES_IN: process.env.JWT_REFRESH_EXPIRES_IN ?? '7d',
-
+  NODE_ENV: process.env.NODE_ENV ?? 'development',
   FE_HOST: process.env.FE_HOST ?? '',
   FE_PORT: parseInt(process.env.FE_PORT ?? '5173', 10) ?? 5173,
   API_URL: `${process.env.BE_HOST ?? 'http://localhost'}:${process.env.PORT ?? '8000'}`,
   CRYPTO_KEY: process.env.CRYPTO_KEY ?? 'crypto-secret-key',
 };
-console.log('configConstants', configConstants);
+if (configConstants.NODE_ENV === 'development') {
+  console.log('configConstants', configConstants);
+}
 
 export default configConstants;

--- a/src/controllers/document/document.controller.ts
+++ b/src/controllers/document/document.controller.ts
@@ -23,7 +23,6 @@ export class DocumentController {
       }
 
       const absolutePath = path.resolve(document.path);
-      console.log('Document absolute path:', absolutePath);
 
       if (!fs.existsSync(`.${absolutePath}`)) {
         return ProcessError(new NotFoundException('Document file not found'), res);

--- a/src/controllers/document/document.controller.ts
+++ b/src/controllers/document/document.controller.ts
@@ -14,11 +14,9 @@ export class DocumentController {
 
   async getDocument(req: Request, res: Response): Promise<void> {
     const { id } = req.params;
-    if (!isStringNumber(id)) {
-      throw new BadRequestException('Invalid document ID format');
-    }
+    const decodedBase64Id = Buffer.from(id, 'base64').toString('utf-8');
     try {
-      const document = await this.documentService.getDocumentById(Number(id));
+      const document = await this.documentService.getDocumentById(decodedBase64Id);
 
       if (!document) {
         throw new NotFoundException('Document not found');

--- a/src/controllers/license/license.controller.ts
+++ b/src/controllers/license/license.controller.ts
@@ -3,27 +3,66 @@ import { HttpStatusCode } from 'axios';
 import { Request, Response } from 'express';
 import { Op } from 'sequelize';
 import { PaginationResult } from '../../database/models/base.model';
-import { LicenseAttributes } from '../../database/models/license.model';
+import { LicenseAttributes, LISENCE_CONSTANTS } from '../../database/models/license.model';
 import { ProcessError } from '../../helper/Error/errorHandler';
 import { ResponseApi } from '../../helper/interface/response.interface';
 import LicenseService from '../../service/license/license.service';
+import { DocumentService } from '../../service/document/document.service';
+import { CreateLisenceDto } from '../../common/dto/lisence/CreateLisenceDto';
+import { BadRequestException } from '../../helper/Error/BadRequestException/BadRequestException';
+import fs from 'fs';
 
 export class LicenseController {
-  private licenseService: LicenseService; // Replace with actual service type
+  private licenseService: LicenseService;
+  private documentService: DocumentService;
 
   constructor() {
-    this.licenseService = new LicenseService(); // Initialize with actual service instance
+    this.licenseService = new LicenseService();
+    this.documentService = new DocumentService();
   }
 
   async create(req: Request, res: Response<ResponseApi<LicenseAttributes>>) {
     try {
-      const result = await this.licenseService.create(req.body);
+      const files = req.files as { [fieldname: string]: Express.Multer.File[] };
+      const payload = req.body as CreateLisenceDto;
+
+      const filePKS = files['file_pks']?.[0];
+      const fileBAST = files['file_bast']?.[0];
+
+      if (!filePKS || !fileBAST) {
+        throw new BadRequestException('Both file_pks and file_bast are required');
+      }
+      const license = await this.licenseService.create(payload);
+
+      const pksFile = await this.documentService.saveDocument({
+        file_type: 'file_pks_lisence',
+        filename: filePKS.filename,
+        path: LISENCE_CONSTANTS.BASE_PATH + license.id + '/' + filePKS.filename,
+      });
+
+      const bastFile = await this.documentService.saveDocument({
+        file_type: 'file_bast_lisence',
+        filename: fileBAST.filename,
+        path: LISENCE_CONSTANTS.BASE_PATH + license.id + '/' + fileBAST.filename,
+      });
+
+      await license.update({
+        pksFileId: pksFile.id,
+        bastFileId: bastFile.id,
+      });
+
       res.status(HttpStatusCode.Created).json({
         message: 'License created successfully',
         statusCode: HttpStatusCode.Created,
-        data: result,
+        data: this.licenseService.licenseResponse(license),
       });
     } catch (err) {
+      const files = req.files as { [fieldname: string]: Express.Multer.File[] };
+      [files['file_pks']?.[0].path ?? '', files['file_bast']?.[0].path ?? ''].forEach((filePath) => {
+        if (filePath && fs.existsSync(filePath)) {
+          fs.unlinkSync(filePath);
+        }
+      });
       ProcessError(err, res);
     }
   }

--- a/src/controllers/license/license.controller.ts
+++ b/src/controllers/license/license.controller.ts
@@ -11,6 +11,7 @@ import { DocumentService } from '../../service/document/document.service';
 import { CreateLisenceDto } from '../../common/dto/lisence/CreateLisenceDto';
 import { BadRequestException } from '../../helper/Error/BadRequestException/BadRequestException';
 import fs from 'fs';
+import { isStringNumber } from '../../helper/function/common';
 
 export class LicenseController {
   private licenseService: LicenseService;
@@ -50,7 +51,6 @@ export class LicenseController {
         pksFileId: pksFile.id,
         bastFileId: bastFile.id,
       });
-
       res.status(HttpStatusCode.Created).json({
         message: 'License created successfully',
         statusCode: HttpStatusCode.Created,
@@ -97,12 +97,48 @@ export class LicenseController {
 
   async update(req: Request, res: Response<ResponseApi<LicenseAttributes>>) {
     try {
-      const id = parseInt(req.params.id, 10);
-      const updatedLicense = await this.licenseService.updateById(id, req.body);
+      const id = req.params.id;
+
+      const files = req.files as { [fieldname: string]: Express.Multer.File[] };
+      const payload = req.body as CreateLisenceDto;
+
+      const filePKS = files['file_pks']?.[0];
+      const fileBAST = files['file_bast']?.[0];
+
+      if (!isStringNumber(id)) {
+        throw new BadRequestException('Invalid Url');
+      }
+
+      const licenseId = parseInt(id, 10);
+
+      const license = await this.licenseService.getById(licenseId);
+
+      let filePksId: number | undefined;
+      let fileBastId: number | undefined;
+      if (filePKS) {
+        const pksFile = await this.documentService.saveDocument({
+          file_type: 'file_pks_lisence',
+          filename: filePKS.filename,
+          path: LISENCE_CONSTANTS.BASE_PATH + license.id + '/' + filePKS.filename,
+        });
+        filePksId = pksFile.id;
+      }
+
+      if (fileBAST) {
+        const bastFile = await this.documentService.saveDocument({
+          file_type: 'file_bast_lisence',
+          filename: fileBAST.filename,
+          path: LISENCE_CONSTANTS.BASE_PATH + license.id + '/' + fileBAST.filename,
+        });
+        fileBastId = bastFile.id;
+      }
+
+      const updatedLicense = await this.licenseService.updateById(licenseId, payload, filePksId, fileBastId);
+      console.log('Updated License:', updatedLicense);
       res.status(HttpStatusCode.Ok).json({
         message: 'License updated successfully',
         statusCode: HttpStatusCode.Ok,
-        data: updatedLicense,
+        data: this.licenseService.licenseResponse(updatedLicense),
       });
     } catch (err) {
       ProcessError(err, res);

--- a/src/controllers/license/license.controller.ts
+++ b/src/controllers/license/license.controller.ts
@@ -134,7 +134,6 @@ export class LicenseController {
       }
 
       const updatedLicense = await this.licenseService.updateById(licenseId, payload, filePksId, fileBastId);
-      console.log('Updated License:', updatedLicense);
       res.status(HttpStatusCode.Ok).json({
         message: 'License updated successfully',
         statusCode: HttpStatusCode.Ok,

--- a/src/controllers/msa/msa.controller.ts
+++ b/src/controllers/msa/msa.controller.ts
@@ -107,7 +107,7 @@ export class MsaController {
       const fileBAST = files['file_bast']?.[0];
 
       if (!isStringNumber(id)) {
-        throw new BadRequestException('Invalid MSA ID');
+        throw new BadRequestException('Invalid Url');
       }
 
       const msaId = parseInt(id, 10);
@@ -157,7 +157,7 @@ export class MsaController {
       res.status(HttpStatusCode.Ok).json({
         statusCode: HttpStatusCode.Ok,
         message: 'MSA updated successfully',
-        data: result,
+        data: this.msaService.MsaResponse(result),
       });
     } catch (err) {
       ProcessError(err, res);

--- a/src/controllers/msa/msa.controller.ts
+++ b/src/controllers/msa/msa.controller.ts
@@ -3,19 +3,16 @@ import { Request, Response } from 'express';
 import * as fs from 'fs';
 import { DateTime } from 'luxon';
 import { Op } from 'sequelize';
+import CreateMsaDto from '../../common/dto/msa/CreateMsaDto';
 import { PaginationResult, SearchCondition } from '../../database/models/base.model';
 import { MSA_CONSTANTS, MsaAttributes } from '../../database/models/msa.model';
 import { BadRequestException } from '../../helper/Error/BadRequestException/BadRequestException';
 import { ProcessError } from '../../helper/Error/errorHandler';
 import { isStringNumber } from '../../helper/function/common';
 import { ResponseApi } from '../../helper/interface/response.interface';
+import { DocumentService } from '../../service/document/document.service';
 import MsaService from '../../service/msa/msa.service';
 import MsaDetailService from '../../service/msa/msaDetail.service';
-import CreateMsaDto from '../../common/dto/msa/CreateMsaDto';
-import { UnprocessableEntityException } from '../../helper/Error/UnprocessableEntity/UnprocessableEntityException';
-import { DocumentService } from '../../service/document/document.service';
-import path from 'path';
-// import * as fs from 'fs';
 
 export class MsaController {
   private msaService: MsaService;

--- a/src/database/migrations/20250729041122-licenses.js
+++ b/src/database/migrations/20250729041122-licenses.js
@@ -16,10 +16,22 @@ module.exports = {
       pks_file_id: {
         type: Sequelize.INTEGER,
         allowNull: true,
+        references: {
+          model: {
+            tableName: 'documents',
+          },
+          key: 'id',
+        },
       },
       bast_file_id: {
         type: Sequelize.INTEGER,
         allowNull: true,
+        references: {
+          model: {
+            tableName: 'documents',
+          },
+          key: 'id',
+        },
       },
       application: {
         type: Sequelize.STRING,

--- a/src/database/migrations/20250729041122-licenses.js
+++ b/src/database/migrations/20250729041122-licenses.js
@@ -3,13 +3,6 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface, Sequelize) {
-    /**
-     * Add altering commands here.
-     *
-     * Example:
-     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
-     */
-
     await queryInterface.createTable('licenses', {
       id: {
         type: Sequelize.INTEGER,
@@ -20,24 +13,28 @@ module.exports = {
         type: Sequelize.STRING,
         allowNull: false,
       },
-      bast: {
-        type: Sequelize.STRING,
-        allowNull: false,
+      pks_file_id: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
       },
-      aplikasi: {
+      bast_file_id: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+      },
+      application: {
         type: Sequelize.STRING,
         allowNull: false,
       },
       due_date_license: {
-        type: Sequelize.DATE,
+        type: Sequelize.DATEONLY,
         allowNull: true,
       },
       health_check_routine: {
-        type: Sequelize.DATE,
+        type: Sequelize.DATEONLY,
         allowNull: true,
       },
       health_check_actual: {
-        type: Sequelize.DATE,
+        type: Sequelize.DATEONLY,
         allowNull: true,
       },
       created_at: {
@@ -58,13 +55,6 @@ module.exports = {
   },
 
   async down(queryInterface, Sequelize) {
-    /**
-     * Add reverting commands here.
-     *
-     * Example:
-     * await queryInterface.dropTable('users');
-     */
-
     await queryInterface.dropTable('licenses');
   },
 };

--- a/src/database/models/license.model.ts
+++ b/src/database/models/license.model.ts
@@ -1,24 +1,33 @@
 import { DataTypes } from 'sequelize';
 import BaseModel, { BaseModelAttributes, baseModelConfig, baseModelInit } from './base.model';
+import Document from './document.model';
 
+export const LISENCE_CONSTANTS = {
+  BASE_PATH: '/uploads/lisence/',
+};
 export interface LicenseAttributes extends BaseModelAttributes {
   pks: string;
-  bast: string;
-  aplikasi: string;
-  dueDateLicense: Date;
-  healthCheckRoutine: Date;
-  healthCheckActual: Date;
+  pksFileId?: number;
+  bastFileId?: number;
+  application: string;
+  dueDateLicense: string;
+  healthCheckRoutine: string;
+  healthCheckActual: string;
+
+  pksFileUrl?: string;
+  bastFileUrl?: string;
 }
 
 export interface LicenseCreationAttributes extends Omit<LicenseAttributes, 'id'> {}
 
 class License extends BaseModel<LicenseAttributes, LicenseCreationAttributes> implements LicenseAttributes {
   public pks!: string;
-  public bast!: string;
-  public aplikasi!: string;
-  public dueDateLicense!: Date;
-  public healthCheckRoutine!: Date;
-  public healthCheckActual!: Date;
+  public pksFileId?: number;
+  public bastFileId?: number;
+  public application!: string;
+  public dueDateLicense!: string;
+  public healthCheckRoutine!: string;
+  public healthCheckActual!: string;
 }
 
 License.init(
@@ -28,24 +37,36 @@ License.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    bast: {
-      type: DataTypes.STRING,
-      allowNull: false,
+    pksFileId: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      references: {
+        model: 'documents',
+        key: 'id',
+      },
     },
-    aplikasi: {
+    bastFileId: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      references: {
+        model: 'documents',
+        key: 'id',
+      },
+    },
+    application: {
       type: DataTypes.STRING,
       allowNull: false,
     },
     dueDateLicense: {
-      type: DataTypes.DATE,
-      allowNull: false,
+      type: DataTypes.STRING,
+      allowNull: true,
     },
     healthCheckRoutine: {
-      type: DataTypes.DATE,
-      allowNull: false,
+      type: DataTypes.STRING,
+      allowNull: true,
     },
     healthCheckActual: {
-      type: DataTypes.DATE,
+      type: DataTypes.STRING,
       allowNull: true,
     },
   },
@@ -54,5 +75,15 @@ License.init(
     tableName: 'licenses',
   }
 );
+
+License.belongsTo(Document, {
+  foreignKey: 'pks_file_id',
+  as: 'pksFile',
+});
+
+License.belongsTo(Document, {
+  foreignKey: 'bast_file_id',
+  as: 'bastFile',
+});
 
 export default License;

--- a/src/middleware/multer.middleware.ts
+++ b/src/middleware/multer.middleware.ts
@@ -61,3 +61,4 @@ export function createFlexibleUploadMiddleware(fields: string[]) {
 }
 
 export const uploadForMSA = createFlexibleUploadMiddleware(['file_pks', 'file_bast']);
+export const uploadForLicense = createFlexibleUploadMiddleware(['file_pks', 'file_bast']);

--- a/src/middleware/validation.middleware.ts
+++ b/src/middleware/validation.middleware.ts
@@ -7,10 +7,8 @@ import { messages } from '../config/message';
 
 export function validationMiddleware<T extends object>(type: new () => T) {
   return async (req: Request, res: Response, next: NextFunction) => {
-    console.log(req.body);
     const dto = plainToInstance(type, req.body);
     const errors: ValidationError[] = await validate(dto);
-
 
     if (errors.length > 0) {
       const errorResponse: ResponseApi<any> = {

--- a/src/routes/license/license.route.ts
+++ b/src/routes/license/license.route.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { LicenseController } from '../../controllers/license/license.controller';
 import { validationMiddleware } from '../../middleware/validation.middleware';
 import { CreateLisenceDto } from '../../common/dto/lisence/CreateLisenceDto';
+import { uploadForLicense } from '../../middleware/multer.middleware';
 
 export default class LicenseRoute {
   router: Router;
@@ -15,12 +16,16 @@ export default class LicenseRoute {
   serve() {
     this.router
       .route('/')
-      .post(validationMiddleware(CreateLisenceDto), (req, res) => this.licenseController.create(req, res))
+      .post(uploadForLicense, validationMiddleware(CreateLisenceDto), (req, res) =>
+        this.licenseController.create(req, res)
+      )
       .get((req, res) => this.licenseController.index(req, res));
     this.router
       .route('/:id')
       .get((req, res) => this.licenseController.show(req, res))
       .delete((req, res) => this.licenseController.destroy(req, res))
-      .put(validationMiddleware(CreateLisenceDto), (req, res) => this.licenseController.update(req, res));
+      .put(uploadForLicense, validationMiddleware(CreateLisenceDto), (req, res) =>
+        this.licenseController.update(req, res)
+      );
   }
 }

--- a/src/service/document/document.service.ts
+++ b/src/service/document/document.service.ts
@@ -33,7 +33,7 @@ export class DocumentService {
     }
   }
 
-  async getDocumentById(id: number): Promise<Document | null> {
+  async getDocumentById(id: string): Promise<Document | null> {
     return await Document.findByPk(id);
   }
 }

--- a/src/service/license/license.service.ts
+++ b/src/service/license/license.service.ts
@@ -39,12 +39,21 @@ export default class LicenseService {
     return null;
   }
 
-  async updateById(id: number, data: Partial<CreateLisenceDto>): Promise<License> {
+  async updateById(
+    id: number,
+    data: Partial<CreateLisenceDto>,
+    filePksId?: number,
+    fileBastId?: number
+  ): Promise<License> {
     const license = await License.findByPk(id);
     if (!license) {
       throw new NotFoundException('License not found');
     }
-    await license.update(data);
+    await license.update({
+      ...data,
+      pksFileId: filePksId ? filePksId : license.pksFileId,
+      bastFileId: fileBastId ? fileBastId : license.bastFileId,
+    });
     return license;
   }
 
@@ -64,11 +73,11 @@ export default class LicenseService {
     return results;
   }
 
-  licenseResponse(license: License): LicenseAttributes {
+  licenseResponse(license: LicenseAttributes): LicenseAttributes {
     const pksFileBase64 = Buffer.from(license.pksFileId?.toString() || '').toString('base64');
     const bastFileBase64 = Buffer.from(license.bastFileId?.toString() || '').toString('base64');
     return {
-      ...license.toJSON(),
+      ...license,
       pksFileUrl: `/api/document/${pksFileBase64}`,
       bastFileUrl: `/api/document/${bastFileBase64}`,
     };

--- a/src/service/license/license.service.ts
+++ b/src/service/license/license.service.ts
@@ -3,23 +3,23 @@ import { CreateLisenceDto } from '../../common/dto/lisence/CreateLisenceDto';
 import License, { LicenseAttributes } from '../../database/models/license.model';
 import { NotFoundException } from '../../helper/Error/NotFound/NotFoundException';
 import { PaginationResult, SearchCondition } from '../../database/models/base.model';
+import { encrypt } from '../../helper/function/crypto';
 
 export default class LicenseService {
   constructor() {}
 
-  async getById(id: number): Promise<LicenseAttributes> {
+  async getById(id: number): Promise<License> {
     const license = await License.findByPk(id);
     if (!license) {
       throw new NotFoundException('License not found');
     }
-    return license.toJSON();
+    return license;
   }
 
-  async create(data: CreateLisenceDto): Promise<LicenseAttributes> {
+  async create(data: CreateLisenceDto): Promise<License> {
     const license = await License.create({
       pks: data.pks,
-      bast: data.bast,
-      aplikasi: data.aplikasi,
+      application: data.application,
       dueDateLicense: data.due_date_license,
       healthCheckRoutine: data.health_check_routine,
       healthCheckActual: data.health_check_actual,
@@ -27,7 +27,7 @@ export default class LicenseService {
     if (!license) {
       throw new NotFoundException('License not created');
     }
-    return license.toJSON();
+    return license;
   }
 
   async deleteById(id: number): Promise<null> {
@@ -39,13 +39,13 @@ export default class LicenseService {
     return null;
   }
 
-  async updateById(id: number, data: Partial<CreateLisenceDto>): Promise<LicenseAttributes> {
+  async updateById(id: number, data: Partial<CreateLisenceDto>): Promise<License> {
     const license = await License.findByPk(id);
     if (!license) {
       throw new NotFoundException('License not found');
     }
     await license.update(data);
-    return license.toJSON();
+    return license;
   }
 
   async getAll(input: {
@@ -62,5 +62,15 @@ export default class LicenseService {
     });
 
     return results;
+  }
+
+  licenseResponse(license: License): LicenseAttributes {
+    const pksFileBase64 = Buffer.from(license.pksFileId?.toString() || '').toString('base64');
+    const bastFileBase64 = Buffer.from(license.bastFileId?.toString() || '').toString('base64');
+    return {
+      ...license.toJSON(),
+      pksFileUrl: `/api/document/${pksFileBase64}`,
+      bastFileUrl: `/api/document/${bastFileBase64}`,
+    };
   }
 }

--- a/src/service/msa/msa.service.ts
+++ b/src/service/msa/msa.service.ts
@@ -31,7 +31,7 @@ export default class MsaService {
     return await this.getById(msa.id);
   }
 
-  async updateById(id: number, data: CreateMsaDto, filePksId?: number, fileBastId?: number): Promise<MsaAttributes> {
+  async updateById(id: number, data: CreateMsaDto, filePksId?: number, fileBastId?: number): Promise<Msa> {
     const msa = await this.getById(id);
 
     if (!msa) {

--- a/src/service/msa/msa.service.ts
+++ b/src/service/msa/msa.service.ts
@@ -8,6 +8,7 @@ import { NotFoundException } from '../../helper/Error/NotFound/NotFoundException
 import MsaDetailService from './msaDetail.service';
 import { UnprocessableEntityException } from '../../helper/Error/UnprocessableEntity/UnprocessableEntityException';
 import Document from '../../database/models/document.model';
+import { encrypt } from '../../helper/function/crypto';
 export default class MsaService {
   private msaDetailService: MsaDetailService;
   constructor() {
@@ -96,10 +97,12 @@ export default class MsaService {
   }
 
   MsaResponse(msa: Msa): MsaAttributes {
+    const pksFileIdBase64 = Buffer.from(msa.pksFileId?.toString() || '').toString('base64');
+    const bastFileIdBase64 = Buffer.from(msa.bastFileId?.toString() || '').toString('base64');
     return {
       ...msa.toJSON(),
-      pksFileUrl: `/api/document/${msa.pksFileId}`,
-      bastFileUrl: `/api/document/${msa.bastFileId}`,
+      pksFileUrl: `/api/document/${pksFileIdBase64}`,
+      bastFileUrl: `/api/document/${bastFileIdBase64}`,
     };
   }
 


### PR DESCRIPTION
This pull request introduces significant changes to the license management system, focusing on improving data structure, validation, and file handling. The updates include modifications to DTOs, controllers, services, database models, and routes. Additionally, new functionality for handling associated documents has been implemented, along with adjustments to database migrations and middleware.

### Changes to License Management

#### Data Structure and Validation Updates:
- Enhanced validation in `CreateLisenceDto` by adding the `@IsNotEmpty()` decorator for required fields and changing field names (`aplikasi` to `application`) for better clarity. Updated date fields to use `string` instead of `Date`. (`[src/common/dto/lisence/CreateLisenceDto.tsL1-R27](diffhunk://#diff-d474c582bdba1fc1a3aad6c4841fac6fb5c7152b47de6d5386d7287d95a9a1f1L1-R27)`)
- Adjusted database model `License` to include `pksFileId` and `bastFileId` as foreign keys referencing the `documents` table. Updated attributes to reflect these changes and added associations to `Document`. (`[[1]](diffhunk://#diff-059c604934f13653f118b898955a206186b22236b46d58dde6d25ef1c8c6a03bR3-R30)`, `[[2]](diffhunk://#diff-059c604934f13653f118b898955a206186b22236b46d58dde6d25ef1c8c6a03bL31-R69)`, `[[3]](diffhunk://#diff-059c604934f13653f118b898955a206186b22236b46d58dde6d25ef1c8c6a03bR79-R88)`)
- Updated database migration for `licenses` table to reflect new fields (`pks_file_id`, `bast_file_id`) and changed date fields to `DATEONLY`. (`[src/database/migrations/20250729041122-licenses.jsL23-R49](diffhunk://#diff-0edaf09c08548159fb6ed1a8c89fb2d3ee5b75319f49f97e9cc720d9642bd3c8L23-R49)`)

#### Controller Enhancements:
- Modified `LicenseController` to handle file uploads (`file_pks`, `file_bast`) during license creation and updates. Integrated document saving logic and updated license records with associated document IDs. Added error handling to clean up uploaded files if an error occurs. (`[[1]](diffhunk://#diff-b94a144884f6233f30c6590f80c740afcb9528d5a952bd3ef36d360d5e88b347L6-R65)`, `[[2]](diffhunk://#diff-b94a144884f6233f30c6590f80c740afcb9528d5a952bd3ef36d360d5e88b347L61-R140)`)
- Updated `DocumentController` to decode base64-encoded document IDs for retrieval. (`[src/controllers/document/document.controller.tsL17-L28](diffhunk://#diff-ac1cbe2f7cc62a3efac99cc234ac77fd94b2a9268e22d36860454e5e2c9d1ceaL17-L28)`)

#### Service Improvements:
- Enhanced `LicenseService` to include methods for creating and updating licenses with associated document IDs. Added `licenseResponse` to generate URLs for associated documents. (`[[1]](diffhunk://#diff-02f3fe5a5043cbf8d0b13a625f8c31c02d98f383df70fef5496057175c0628f0R6-R30)`, `[[2]](diffhunk://#diff-02f3fe5a5043cbf8d0b13a625f8c31c02d98f383df70fef5496057175c0628f0L42-R57)`, `[[3]](diffhunk://#diff-02f3fe5a5043cbf8d0b13a625f8c31c02d98f383df70fef5496057175c0628f0R75-R84)`)
- Adjusted `DocumentService` to accept string IDs for document retrieval. (`[src/service/document/document.service.tsL36-R36](diffhunk://#diff-1faa348ecf444d5b91da18ad43268adefc846a4ee6f756fb06ff013b5b4368dcL36-R36)`)

### Changes to Middleware and Routes

#### Middleware Updates:
- Added `uploadForLicense` middleware for handling file uploads related to licenses. (`[src/middleware/multer.middleware.tsR64](diffhunk://#diff-98774fefc1f56a8bc736ff76e295202e3db719f4a98d9c0c211b80a57eb2ef78R64)`)
- Removed unnecessary debugging logs from `validation.middleware.ts`. (`[src/middleware/validation.middleware.tsL10-L14](diffhunk://#diff-a81c7b6c2247892e3ab035831df04508d00f48e7588efbde4601e82b5fe029f5L10-L14)`)

#### Route Updates:
- Integrated `uploadForLicense` middleware into license routes for handling file uploads during creation and updates. (`[[1]](diffhunk://#diff-b5d7bf70debc474346ac91e9063eaac21e41eb7e155c1c018492e1d7d9e3b115R5)`, `[[2]](diffhunk://#diff-b5d7bf70debc474346ac91e9063eaac21e41eb7e155c1c018492e1d7d9e3b115L18-R29)`)

### Other Changes

#### Configuration Updates:
- Added `NODE_ENV` to configuration constants and included a conditional log for development environments. (`[src/config/constants.tsL20-R28](diffhunk://#diff-143d78eb344aee71bd9eff746283b5b3f8ac16dfe6be2091e29f678324100c00L20-R28)`)

#### Miscellaneous:
- Minor adjustments to `MsaController` for consistency in error messages and response formatting. (`[[1]](diffhunk://#diff-e7b8e50820000bed293cb67c28b9ce7634f5349d20936c9044eb8987bcf7591eL113-R110)`, `[[2]](diffhunk://#diff-e7b8e50820000bed293cb67c28b9ce7634f5349d20936c9044eb8987bcf7591eL163-R160)`)