### PR TITLE
Uses CURRENT_TIMESTAMP for date defaults in migrations

### DIFF
--- a/src/database/migrations/20250806062132-links.js
+++ b/src/database/migrations/20250806062132-links.js
@@ -25,12 +25,12 @@ module.exports = {
       created_at: {
         allowNull: false,
         type: Sequelize.DATE,
-        defaultValue: Sequelize.fn('NOW'),
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
       },
       updated_at: {
         allowNull: false,
         type: Sequelize.DATE,
-        defaultValue: Sequelize.fn('NOW'),
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
       },
       deleted_at: {
         type: Sequelize.DATE,


### PR DESCRIPTION
Switches date column default values from a function-based approach to a raw SQL literal for improved database compatibility and clarity in generated timestamps.