### PR TITLE
Feat/license file using url

### DIFF
--- a/src/common/dto/lisence/CreateLisenceDto.ts
+++ b/src/common/dto/lisence/CreateLisenceDto.ts
@@ -25,4 +25,12 @@ export class CreateLisenceDto {
 
   @IsDateString()
   health_check_actual!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  file_pks!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  file_bast!: string;
 }

--- a/src/controllers/license/license.controller.ts
+++ b/src/controllers/license/license.controller.ts
@@ -27,30 +27,30 @@ export class LicenseController {
       const files = req.files as { [fieldname: string]: Express.Multer.File[] };
       const payload = req.body as CreateLisenceDto;
 
-      const filePKS = files['file_pks']?.[0];
-      const fileBAST = files['file_bast']?.[0];
+      // const filePKS = files['file_pks']?.[0];
+      // const fileBAST = files['file_bast']?.[0];
 
-      if (!filePKS || !fileBAST) {
-        throw new BadRequestException('Both file_pks and file_bast are required');
-      }
+      // if (!filePKS || !fileBAST) {
+      //   throw new BadRequestException('Both file_pks and file_bast are required');
+      // }
       const license = await this.licenseService.create(payload);
 
-      const pksFile = await this.documentService.saveDocument({
-        file_type: 'file_pks_lisence',
-        filename: filePKS.filename,
-        path: LISENCE_CONSTANTS.BASE_PATH + license.id + '/' + filePKS.filename,
-      });
+      // const pksFile = await this.documentService.saveDocument({
+      //   file_type: 'file_pks_lisence',
+      //   filename: filePKS.filename,
+      //   path: LISENCE_CONSTANTS.BASE_PATH + license.id + '/' + filePKS.filename,
+      // });
 
-      const bastFile = await this.documentService.saveDocument({
-        file_type: 'file_bast_lisence',
-        filename: fileBAST.filename,
-        path: LISENCE_CONSTANTS.BASE_PATH + license.id + '/' + fileBAST.filename,
-      });
+      // const bastFile = await this.documentService.saveDocument({
+      //   file_type: 'file_bast_lisence',
+      //   filename: fileBAST.filename,
+      //   path: LISENCE_CONSTANTS.BASE_PATH + license.id + '/' + fileBAST.filename,
+      // });
 
-      await license.update({
-        pksFileId: pksFile.id,
-        bastFileId: bastFile.id,
-      });
+      // await license.update({
+      //   pksFileId: pksFile.id,
+      //   bastFileId: bastFile.id,
+      // });
       res.status(HttpStatusCode.Created).json({
         message: 'License created successfully',
         statusCode: HttpStatusCode.Created,

--- a/src/database/migrations/20250808071243-add_file_pks_file_bast_license.js
+++ b/src/database/migrations/20250808071243-add_file_pks_file_bast_license.js
@@ -1,0 +1,33 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    /**
+     * Add altering commands here.
+     *
+     * Example:
+     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
+     */
+    await queryInterface.addColumn('licenses', 'file_pks', {
+      type: Sequelize.STRING,
+      allowNull: false,
+    });
+
+    await queryInterface.addColumn('licenses', 'file_bast', {
+      type: Sequelize.STRING,
+      allowNull: false,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+    await queryInterface.removeColumn('licenses', 'file_pks');
+    await queryInterface.removeColumn('licenses', 'file_bast');
+  },
+};

--- a/src/database/models/license.model.ts
+++ b/src/database/models/license.model.ts
@@ -13,6 +13,8 @@ export interface LicenseAttributes extends BaseModelAttributes {
   dueDateLicense: string;
   healthCheckRoutine: string;
   healthCheckActual: string;
+  filePks: string;
+  fileBast: string;
 
   pksFileUrl?: string;
   bastFileUrl?: string;
@@ -31,6 +33,8 @@ class License extends BaseModel<LicenseAttributes, LicenseCreationAttributes> im
   public dueDateLicense!: string;
   public healthCheckRoutine!: string;
   public healthCheckActual!: string;
+  public filePks!: string;
+  public fileBast!: string;
 }
 
 License.init(
@@ -83,6 +87,14 @@ License.init(
         const value = this.getDataValue('healthCheckActual');
         return value ? new Date(value).toISOString() : null;
       },
+    },
+    filePks: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    fileBast: {
+      type: DataTypes.STRING,
+      allowNull: false,
     },
   },
   {

--- a/src/service/license/license.service.ts
+++ b/src/service/license/license.service.ts
@@ -22,6 +22,8 @@ export default class LicenseService {
       dueDateLicense: data.due_date_license,
       healthCheckRoutine: data.health_check_routine,
       healthCheckActual: data.health_check_actual,
+      filePks: data.file_pks,
+      fileBast: data.file_bast,
     });
     if (!license) {
       throw new NotFoundException('License not created');
@@ -56,6 +58,7 @@ export default class LicenseService {
       healthCheckActual: data.health_check_actual,
       pksFileId: filePksId ? filePksId : license.pksFileId,
       bastFileId: fileBastId ? fileBastId : license.bastFileId,
+
     });
     return license;
   }

--- a/src/service/v2/msa/msaDetailV2.service.ts
+++ b/src/service/v2/msa/msaDetailV2.service.ts
@@ -43,4 +43,11 @@ export class MsaV2Service {
 
     return msa;
   }
+
+  async deleteByMsaId(pksMsaId: number, transaction?: Transaction): Promise<void> {
+    const msa = await V2Msa.destroy({
+      where: { pksMsaId },
+      transaction,
+    });
+  }
 }


### PR DESCRIPTION
This pull request introduces several changes related to the handling of license files and improvements to MSA (Master Service Agreement) management. The main updates include adding new fields for license file references, updating the database schema, and improving validation and transaction handling in MSA operations.

**License file handling enhancements:**

* Added new required string fields, `file_pks` and `file_bast`, to the `CreateLisenceDto` DTO for capturing license file references.
* Updated the database schema and Sequelize model (`license.model.ts`) to include `filePks` and `fileBast` fields, ensuring these are now required columns in the `licenses` table. [[1]](diffhunk://#diff-9979b0f1e103d6ec7f05b1920dbc01e5f15668bd8544d6e55fcaa022fa500788R1-R33) [[2]](diffhunk://#diff-059c604934f13653f118b898955a206186b22236b46d58dde6d25ef1c8c6a03bR16-R17) [[3]](diffhunk://#diff-059c604934f13653f118b898955a206186b22236b46d58dde6d25ef1c8c6a03bR36-R37) [[4]](diffhunk://#diff-059c604934f13653f118b898955a206186b22236b46d58dde6d25ef1c8c6a03bR91-R98)
* Modified the `LicenseService` to store the new `filePks` and `fileBast` fields when creating a license.
* Commented out previous logic in the `LicenseController` that handled file uploads and document saving for `file_pks` and `file_bast`, shifting the responsibility to the new fields.

**MSA management improvements:**

* Added a new `deleteByMsaId` method to `MsaV2Service` for deleting MSA records by ID within a transaction.
* Updated `MsaDetailV2Controller` to delete existing MSA data before fetching and processing PKS data, ensuring transactional integrity.
* Added validation to ensure the total number of people assigned to a contract does not exceed the allowed quota, throwing a `BadRequestException` if the limit is surpassed.